### PR TITLE
update mixin class

### DIFF
--- a/eessi/testsuite/eessi_mixin.py
+++ b/eessi/testsuite/eessi_mixin.py
@@ -46,7 +46,8 @@ class EESSI_Mixin(RegressionMixin):
         super().__init_subclass__(**kwargs)
         cls.valid_prog_environs = ['default']
         cls.valid_systems = ['*']
-        cls.time_limit = '1h'
+        if not cls.time_limit:
+            cls.time_limit = '1h'
 
     # Helper function to validate if an attribute is present it item_dict.
     # If not, print it's current name, value, and the valid_values

--- a/eessi/testsuite/tests/apps/lammps/lammps.py
+++ b/eessi/testsuite/tests/apps/lammps/lammps.py
@@ -12,10 +12,7 @@ from eessi.testsuite.eessi_mixin import EESSI_Mixin
 
 
 class EESSI_LAMMPS_base(rfm.RunOnlyRegressionTest, EESSI_Mixin):
-    valid_prog_environs = ['default']
-    valid_systems = ['*']
     time_limit = '30m'
-
     device_type = parameter([DEVICE_TYPES[CPU], DEVICE_TYPES[GPU]])
 
     # Parameterize over all modules that start with LAMMPS


### PR DESCRIPTION
- replace `ReframeSyntaxError` with `ReframeFatalError` so we error out immediately instead of trying and failing every test combination
- use `__init_subclass__()` to set default values for built-in ReFrame attributes
- update `validate_item_in_dict()` so it also works with lists as value

i also removed the eessi testsuite version stuff for now, so we don't have to wait for the other PR for this to get merged.
feel free to add it back in if you disagree :)